### PR TITLE
検索クエリ生成処理追加・画像URLの処理追加

### DIFF
--- a/src/main/java/com/pontsuyo/tweet/analyzer/loader/domain/model/Tweet.java
+++ b/src/main/java/com/pontsuyo/tweet/analyzer/loader/domain/model/Tweet.java
@@ -1,12 +1,18 @@
 package com.pontsuyo.tweet.analyzer.loader.domain.model;
 
-import java.util.Collections;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import twitter4j.MediaEntity;
 import twitter4j.Status;
 
+@Slf4j
 @Builder
 public class Tweet {
 
@@ -16,31 +22,59 @@ public class Tweet {
 
   private final String text;
 
-  private final List<String> imageUrls;
-
   private final Integer favoriteCount;
 
   private final Integer retweetCount;
+
+  private final List<String> imageUrls;
+
+  // note ComponentクラスでAutowiredしたものを使うにはtoQueryMap()ごと移動する必要あり
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
   public static Tweet fromStatus(Status status) {
     return Tweet.builder()
         .tweetId(status.getId())
         .userId(status.getUser().getId())
         .text(status.getText())
-        .imageUrls(Collections.emptyList()) // todo 仮置き
         .favoriteCount(status.getFavoriteCount())
         .retweetCount(status.getFavoriteCount())
+        .imageUrls(getMediaUrlList(status))
         .build();
   }
 
-  public Map<String, AttributeValue> toQueryMap() {
-    // todo imageUrlsのsetの仕方を考える
+  static private List<String> getMediaUrlList(Status status) {
+    return Arrays.stream(status.getMediaEntities()).sequential()
+        .map(MediaEntity::getMediaURL)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * DynamoDBのRepositoryに渡すクエリに変換する
+   * <p>
+   * AttributeValue.ss()はset（要素順序を保証しない）でしか書き込めないので
+   * image_urlsの書き込み時は、シリアライズしてAttributeValue.s()を使用する。
+   *
+   * @return DynamoDB用書き込みクエリ
+   */
+  public Map<String, AttributeValue> convertToQueryMap() {
     return Map.of(
         "id", AttributeValue.builder().n(tweetId.toString()).build(),
         "text", AttributeValue.builder().s(text).build(),
         "user_id", AttributeValue.builder().n(userId.toString()).build(),
         "favorite_count", AttributeValue.builder().n(favoriteCount.toString()).build(),
-        "retweet_count", AttributeValue.builder().n(retweetCount.toString()).build()
+        "retweet_count", AttributeValue.builder().n(retweetCount.toString()).build(),
+        "image_urls", AttributeValue.builder().s(objectToString(imageUrls)).build()
     );
+  }
+
+  private String objectToString(Object obj) {
+    String jsonString;
+    try {
+      jsonString = objectMapper.writeValueAsString(obj);
+    } catch (JsonProcessingException e) {
+      log.warn("object serialization failed.", e);
+      return "";
+    }
+    return jsonString;
   }
 }

--- a/src/main/java/com/pontsuyo/tweet/analyzer/loader/domain/model/Tweet.java
+++ b/src/main/java/com/pontsuyo/tweet/analyzer/loader/domain/model/Tweet.java
@@ -49,7 +49,7 @@ public class Tweet {
    *
    * @return DynamoDB用書き込みクエリ
    */
-  public Map<String, AttributeValue> convertToQueryMap() {
+  public Map<String, AttributeValue> convert2QueryMap() {
     return Map.of(
         "id", AttributeValue.builder().n(tweetId.toString()).build(),
         "text", AttributeValue.builder().s(text).build(),

--- a/src/main/java/com/pontsuyo/tweet/analyzer/loader/domain/model/TweetSearchQuery.java
+++ b/src/main/java/com/pontsuyo/tweet/analyzer/loader/domain/model/TweetSearchQuery.java
@@ -1,0 +1,61 @@
+package com.pontsuyo.tweet.analyzer.loader.domain.model;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Objects;
+import lombok.Builder;
+import lombok.Getter;
+import twitter4j.Query;
+
+@Builder
+public class TweetSearchQuery {
+
+  private Language lang;
+  private Date date;
+  private int minFaves;
+
+  /**
+   * repositoryに渡すqueryを生成する
+   *
+   * @return
+   */
+  public Query generateQuery() {
+    var sb = new StringBuilder();
+
+    // HACK 必須要素の設定ロジックもっと綺麗にかけそう
+    sb.append("filter:");
+    sb.append("images");
+
+    if (!lang.equals(Language.NONE)) {
+      // HACK 先頭にスペース挟んでるのあまりに不格好
+      sb.append(" lang:");
+      sb.append(lang.string);
+    }
+
+    if (!(Objects.isNull(date))) {
+      // HACK 先頭にスペース挟んでるのあまりに不格好
+      sb.append(" since:");
+
+      var df = new SimpleDateFormat("yyyy-MM-dd");
+      sb.append(df.format(new Date()));
+    }
+
+    // HACK 先頭にスペース挟んでるのあまりに不格好
+    sb.append(" min_faves:");
+    sb.append(minFaves);
+
+    return new Query(sb.toString());
+  }
+
+  @Getter
+  public enum Language {
+    NONE(""),
+    JAPANESE("ja");
+
+    private String string;
+
+    Language(String string) {
+      this.string = string;
+    }
+  }
+}

--- a/src/main/java/com/pontsuyo/tweet/analyzer/loader/domain/service/TweetService.java
+++ b/src/main/java/com/pontsuyo/tweet/analyzer/loader/domain/service/TweetService.java
@@ -1,10 +1,11 @@
 package com.pontsuyo.tweet.analyzer.loader.domain.service;
 
 import com.pontsuyo.tweet.analyzer.loader.domain.model.Tweet;
+import com.pontsuyo.tweet.analyzer.loader.domain.model.TweetSearchQuery;
 import com.pontsuyo.tweet.analyzer.loader.repository.TweetRepository;
+import java.util.Date;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import twitter4j.Query;
 import twitter4j.QueryResult;
 import twitter4j.Twitter;
 import twitter4j.TwitterException;
@@ -13,8 +14,8 @@ import twitter4j.TwitterException;
 @Service
 public class TweetService {
 
-  // todo 検索クエリは仮置き
-  private static final String TWEET_SEARCH_QUERY = "";
+  // note この値は仮置き
+  private static final int MIN_FAVORITES = 10000;
 
   private final Twitter twitter;
   private final TweetRepository tweetRepository;
@@ -26,7 +27,13 @@ public class TweetService {
 
   public String updateTweets() {
 
-    var query = new Query(TWEET_SEARCH_QUERY);
+    var query = TweetSearchQuery.builder()
+        .date(new Date())
+        .lang(TweetSearchQuery.Language.JAPANESE)
+        .minFaves(MIN_FAVORITES)
+        .build()
+        .generateQuery();
+
     QueryResult result;
 
     try {

--- a/src/main/java/com/pontsuyo/tweet/analyzer/loader/repository/TweetRepository.java
+++ b/src/main/java/com/pontsuyo/tweet/analyzer/loader/repository/TweetRepository.java
@@ -14,7 +14,7 @@ public class TweetRepository {
   public String updateTweet(Tweet tweet) {
     var request = PutItemRequest.builder()
         .tableName("tweet-analyzer")
-        .item(tweet.toQueryMap())
+        .item(tweet.convertToQueryMap())
         .build();
 
     var client = DynamoDbClient.create();

--- a/src/main/java/com/pontsuyo/tweet/analyzer/loader/repository/TweetRepository.java
+++ b/src/main/java/com/pontsuyo/tweet/analyzer/loader/repository/TweetRepository.java
@@ -14,7 +14,7 @@ public class TweetRepository {
   public String updateTweet(Tweet tweet) {
     var request = PutItemRequest.builder()
         .tableName("tweet-analyzer")
-        .item(tweet.convertToQueryMap())
+        .item(tweet.convert2QueryMap())
         .build();
 
     var client = DynamoDbClient.create();


### PR DESCRIPTION
### 変更内容

画像URLはtweetごとに画像順序を保持したままDBに書き込みたいので、DynamoDB Typeとしてはそれが可能そうなL型を使用している