### PR TITLE
DBのkeyをidからtweet_idに変更する

### DIFF
--- a/src/main/java/com/pontsuyo/tweet/analyzer/loader/domain/model/Tweet.java
+++ b/src/main/java/com/pontsuyo/tweet/analyzer/loader/domain/model/Tweet.java
@@ -1,6 +1,5 @@
 package com.pontsuyo.tweet.analyzer.loader.domain.model;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +50,7 @@ public class Tweet {
    */
   public Map<String, AttributeValue> convert2QueryMap() {
     return Map.of(
-        "id", AttributeValue.builder().n(tweetId.toString()).build(),
+        "tweet_id", AttributeValue.builder().n(tweetId.toString()).build(),
         "text", AttributeValue.builder().s(text).build(),
         "user_id", AttributeValue.builder().n(userId.toString()).build(),
         "favorite_count", AttributeValue.builder().n(favoriteCount.toString()).build(),


### PR DESCRIPTION
### 変更内容
`tweet_id`のカラム名は`id`としていたが、これでは`user_id`と区別が付かないため、変更しておきたい。